### PR TITLE
🔒 Security: 認証情報のハードコード除去・ランタイム更新

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -9,12 +9,27 @@ Parameters:
 
   LambdaRuntime:
     Type: String
-    Default: nodejs16.x
+    Default: nodejs20.x
     Description: Lambda関数のランタイム
     AllowedValues:
-      - nodejs14.x
-      - nodejs16.x
       - nodejs18.x
+      - nodejs20.x
+      - nodejs22.x
+
+  JPsonicBaseUrl:
+    Type: String
+    Description: JPsonicサーバーのベースURL（HTTPS推奨）
+    NoEcho: true
+
+  JPsonicUsername:
+    Type: String
+    Description: JPsonicサーバーのユーザー名
+    NoEcho: true
+
+  JPsonicPassword:
+    Type: String
+    Description: JPsonicサーバーのパスワード
+    NoEcho: true
 
 Resources:
   AlexaSkillIAMRole:
@@ -40,18 +55,22 @@ Resources:
       Runtime: !Ref LambdaRuntime
       Timeout: 10
       MemorySize: 128
+      Environment:
+        Variables:
+          JPSONIC_BASE_URL: !Ref JPsonicBaseUrl
+          JPSONIC_USERNAME: !Ref JPsonicUsername
+          JPSONIC_PASSWORD: !Ref JPsonicPassword
       Code:
         ZipFile: |
           // JPsonic Alexa Skill
           const Alexa = require('ask-sdk-core');
           const axios = require('axios');
 
-          // JPsonicサーバーの設定
+          // JPsonicサーバーの設定（環境変数から取得）
           const JPSONIC_CONFIG = {
-            // 実際の環境に合わせて変更してください
-            baseUrl: 'http://your-jpsonic-server:4040',
-            username: 'your-username',
-            password: 'your-password'
+            baseUrl: process.env.JPSONIC_BASE_URL || 'https://your-jpsonic-server:4040',
+            username: process.env.JPSONIC_USERNAME || '',
+            password: process.env.JPSONIC_PASSWORD || ''
           };
 
           // JPsonicへの認証とAPIリクエスト用のヘルパー関数

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -2,12 +2,11 @@
 const Alexa = require('ask-sdk-core');
 const axios = require('axios');
 
-// JPsonicサーバーの設定
+// JPsonicサーバーの設定（環境変数から取得）
 const JPSONIC_CONFIG = {
-  // 実際の環境に合わせて変更してください
-  baseUrl: 'http://your-jpsonic-server:4040',
-  username: 'your-username',
-  password: 'your-password'
+  baseUrl: process.env.JPSONIC_BASE_URL || 'https://your-jpsonic-server:4040',
+  username: process.env.JPSONIC_USERNAME || '',
+  password: process.env.JPSONIC_PASSWORD || ''
 };
 
 // JPsonicへの認証とAPIリクエスト用のヘルパー関数

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "ask-sdk-core": "^2.12.1",
     "ask-sdk-model": "^1.38.1",
-    "axios": "^0.27.2"
+    "axios": "^1.7.9"
   }
 }


### PR DESCRIPTION
## 概要
セキュリティ静的解析により検出された脆弱性を修正します。

## 修正内容
### 🔴 Critical: 認証情報のハードコード (OWASP A02:2021)
- `JPSONIC_CONFIG`の`username`/`password`/`baseUrl`をハードコードから環境変数(`process.env`)に変更
- CloudFormationテンプレートに`NoEcho`パラメータを追加し、認証情報を安全に渡す構成に変更

### 🔴 Critical: HTTP通信 (OWASP A02:2021)
- `baseUrl`のデフォルトを`http://`から`https://`に変更

### 🟡 Medium: 古いランタイム・依存関係 (OWASP A06:2021)
- Node.jsランタイム: `nodejs16.x` → `nodejs20.x`（nodejs16.xはEOL）
- axios: `0.27.2` → `1.7.9`（複数のCVE修正を含む）

## セキュリティ基準
- OWASP Top 10 2021準拠
- SAST静的解析基準